### PR TITLE
Set networking options

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,14 @@
                 assertion = config.boot.loader.grub.device == "/dev/sda";
                 message = "garnix.server needs the boot.loader.grub.device to be \"/dev/sda\"";
               }
+              {
+                assertion = config.networking.useNetworkd == false;
+                message = "garnix.server needs networking.useNetworkd to be false";
+              }
+              {
+                assertion = config.networking.useDHCP;
+                message = "garnix.server needs networking.useDHCP to be true";
+              }
             ];
 
             fileSystems."/" = {
@@ -49,6 +57,8 @@
               fsType = "ext4";
             };
             boot.loader.grub.device = "/dev/sda";
+            networking.useNetworkd = false;
+            networking.useDHCP = true;
           })
 
           (lib.mkIf cfg.persistence.enable {

--- a/flake.nix
+++ b/flake.nix
@@ -57,8 +57,6 @@
               fsType = "ext4";
             };
             boot.loader.grub.device = "/dev/sda";
-            networking.useNetworkd = false;
-            networking.useDHCP = true;
           })
 
           (lib.mkIf cfg.persistence.enable {


### PR DESCRIPTION
These are already the default values, however setting either of these causes the VM to fail to obtain an IP address. Until we figure out the root cause of this we should ensure that these options remain the default value.