### PR TITLE
Add required kernel modules for Hetzner cloud vm

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
 
   outputs = { self, nixpkgs }: {
 
-    nixosModules.garnix = { lib, config, ... }:
+    nixosModules.garnix = { lib, config, modulesPath, ... }:
       let
         cfg = config.garnix.server;
       in
@@ -31,6 +31,8 @@
             };
           };
         };
+
+        imports = [ (modulesPath + "/profiles/qemu-guest.nix") ];
 
         config = lib.mkMerge [
           (lib.mkIf cfg.enable {


### PR DESCRIPTION
Server does not boot without them
