### PR TITLE
Add garnix.config option

### DIFF
--- a/mk-modules.nix
+++ b/mk-modules.nix
@@ -34,6 +34,13 @@ flakeInputs: mkModulesOpts: let
       type = lib.types.attrsOf lib.types.unspecified;
       default = {};
     };
+
+    garnix.config.servers = lib.mkOption {
+      # This type is checked by garnix CI on push
+      # See https://garnix.io/docs/yaml_config for documentation
+      type = lib.types.listOf lib.types.unspecified;
+      default = [];
+    };
   };
 
   evalModules = system: lib.evalModules {
@@ -85,4 +92,6 @@ in {
       }
     ];
   }) evaledModulesForSystem.x86_64-linux.config.nixosConfigurations;
+
+  garnix.config = evaledModulesForSystem.x86_64-linux.config.garnix.config;
 }


### PR DESCRIPTION
Note that I originally tried to capture the proper type here in nix, but it looks like `oneOf` is not powerful enough to handle this. For example setting `garnix.config.servers` to a type including this:

```nix
deployment = mkOption {
  type = types.oneOf [
    (types.submodule {
      options.type = mkOption { type = types.strMatching "on-pull-request"; };
    })
    (types.submodule {
      options.type = mkOption { type = types.strMatching "on-branch"; };
      options.branch = mkOption { type = types.str; };
    })
  ];
};
```

Gives the error `error: The option servers."[definition 1-entry 1]".deployment.branch' is used but not defined.` for the input

```nix
deployment = {
  type = "on-pull-request";
};
```

Also we can't just set `garnix` or `garnix.config` as an option with type `unspecified` as it prevents the lists specified from multiple modules from properly merging.
