### PR TITLE
Update nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1717196966,
-        "narHash": "sha256-yZKhxVIKd2lsbOqYd5iDoUIwsRZFqE87smE2Vzf6Ck0=",
+        "lastModified": 1733940404,
+        "narHash": "sha256-Pj39hSoUA86ZePPF/UXiYHHM7hMIkios8TYG29kQT4g=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "57610d2f8f0937f39dbd72251e9614b1561942d8",
+        "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
I was running into an issue when trying to start NixOS VMs:


```
./result/bin/run-nixos-vm
Disk  image do not exist, creating the virtualisation disk image...
Formatting '/tmp/tmp.s5Tp202tjr', fmt=raw size=1073741824
mke2fs 1.47.0 (5-Feb-2023)
Discarding device blocks: done                            
Creating filesystem with 262144 4k blocks and 65536 inodes
Filesystem UUID: 7d0a78f0-1b80-4351-b1ca-e242429caca9
Superblock backups stored on blocks: 
	32768, 98304, 163840, 229376

Allocating group tables: done                            
Writing inode tables: done                            
Creating journal (8192 blocks): done
Writing superblocks and filesystem accounting information: done

Virtualisation disk image created.
/nix/store/lppf8jfx571k61rp268xyb2675dg88v3-qemu-host-cpu-only-8.2.4/bin/qemu-kvm: symbol lookup error: /nix/store/pbvn150v0w5v1jadv1b8wnvkp81vxz5k-pipewire-1.2.6-jack/lib/libjack.so.0: undefined symbol: pw_log_topic_register
```