### PR TITLE
Let `nixosSystem` evaluate nixos configuration modules

### DIFF
--- a/mk-modules.nix
+++ b/mk-modules.nix
@@ -31,7 +31,7 @@ flakeInputs: mkModulesOpts: let
 
     nixosConfigurations = lib.mkOption {
       # This type will be checked by lib.nixosSystem below
-      type = lib.types.attrsOf lib.types.unspecified;
+      type = lib.types.attrsOf (lib.types.listOf lib.types.unspecified);
       default = {};
     };
 
@@ -73,10 +73,9 @@ in {
       };
   }) evaledModulesForSystem;
 
-  nixosConfigurations = builtins.mapAttrs (name: nixosConfig: lib.nixosSystem {
+  nixosConfigurations = builtins.mapAttrs (name: nixosModules: lib.nixosSystem {
     modules = [
       flakeInputs.self.nixosModules.garnix
-      nixosConfig
       {
         # This sets up networking and filesystems in a way that works with garnix hosting.
         garnix.server.enable = true;
@@ -90,7 +89,7 @@ in {
           users.users.root.password = "";
         };
       }
-    ];
+    ] ++ nixosModules;
   }) evaledModulesForSystem.x86_64-linux.config.nixosConfigurations;
 
   garnix.config = evaledModulesForSystem.x86_64-linux.config.garnix.config;


### PR DESCRIPTION
Since our `nixosConfigurations` type was attrsOf unspecified` merging multiple modules does not work correctly. Instead, this PR makes `nixosConfigurations` be `attrsOf (listOf unspecified)` then passes the list into `nixosSystem` to be merged correctly.