### PR TITLE
Use empty home directory for garnix user

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -114,7 +114,7 @@
             users.users.garnix = {
               description = "A user garnix uses for redeploying ${cfg.persistence.name}";
               isNormalUser = true;
-              createHome = false;
+              home = "/var/empty";
               openssh.authorizedKeys.keys = [
                 "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJTPguYAuqp6qCU43u8g2hgWz4MLCEPPyoVPYO53qB+t garnixServer@garnix.io"
               ];


### PR DESCRIPTION
Prevent `Could not chdir to home directory /home/garnix: No such file or directory` error when garnix user logs in.
