### PR TITLE
Enable automatic GC on persistent deploys

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -109,7 +109,10 @@
               wheelNeedsPassword = false;
             };
 
-            nix.settings.trusted-users = [ "garnix" ];
+            nix = {
+              gc.automatic = true;
+              settings.trusted-users = [ "garnix" ];
+            };
 
             users.users.garnix = {
               description = "A user garnix uses for redeploying ${cfg.persistence.name}";


### PR DESCRIPTION
If you have a persistent server it makes sense that we should default enable automatic GC. This can still be overridden with `lib.mkForce` if users want to manually GC.