### PR TITLE
Make systemd-networkd work (work in progress)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,14 +52,6 @@
                 assertion = cfg.isVM || config.boot.loader.grub.device == "/dev/sda";
                 message = "garnix.server needs the boot.loader.grub.device to be \"/dev/sda\"";
               }
-              {
-                assertion = cfg.isVM || config.networking.useNetworkd == false;
-                message = "garnix.server needs networking.useNetworkd to be false";
-              }
-              {
-                assertion = cfg.isVM || config.networking.useDHCP;
-                message = "garnix.server needs networking.useDHCP to be true";
-              }
             ];
 
             fileSystems."/" = lib.mkIf (!cfg.isVM) {


### PR DESCRIPTION
It does seem to generally work with systemd-networkd, however the interface is stuck `configuring`, and that causes the wait-online unit to time out and fail the deploy. Setting `systemd.network.wait-online.enable` fixes this, however this means you can't depend on `network-online` for user units.

Still trying to figure out what the underlying issue is.